### PR TITLE
Fix to CreatTeam and CreateTeam Test Created

### DIFF
--- a/src/use_case/CreateTeam/CreateTeamInteractor.java
+++ b/src/use_case/CreateTeam/CreateTeamInteractor.java
@@ -3,10 +3,14 @@ package use_case.CreateTeam;
 import app.EntityMemory;
 import data_access.DataAccessInterface;
 import entity.Team;
+import entity.Todo;
 import entity.User;
 import use_case.DeleteTodo.DeleteTodoInputData;
 import use_case.DeleteTodo.DeleteTodoOutputBoundary;
 import use_case.DeleteTodo.DeleteTodoOutputData;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class CreateTeamInteractor implements CreateTeamInputBoundary {
 
@@ -25,7 +29,7 @@ public class CreateTeamInteractor implements CreateTeamInputBoundary {
         try {
             if (dataAccess.readTeam(createTeamInputData.getTeamName()) == null) {
                 // Create Team
-                Team newTeam = new Team(createTeamInputData.getTeamName(), null, null, null);
+                Team newTeam = new Team(createTeamInputData.getTeamName(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
                 // Add team in the user's team list
                 User user = EntityMemory.getLoggedInUser();
                 user.getTeam().add(newTeam.getTeamName());

--- a/test/data_access/DataAccessTest.java
+++ b/test/data_access/DataAccessTest.java
@@ -4,6 +4,7 @@ import entity.Todo;
 import entity.User;
 import entity.Team;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.ArrayList;
@@ -109,6 +110,10 @@ public class DataAccessTest {
         assertEquals(user2.getTaskList().get(0).getName(), users.get(1).getTaskList().get(0).getName());
     }
 
+    @Before
+    public void waitFor2() throws InterruptedException {
+        Thread.sleep(2000);
+    }
 
     @Test
     public void testUpdateUser() {

--- a/test/use_case/CreateTeam/CreateTeamInteractorTest.java
+++ b/test/use_case/CreateTeam/CreateTeamInteractorTest.java
@@ -1,0 +1,73 @@
+package use_case.CreateTeam;
+
+import app.EntityMemory;
+import data_access.DataAccess;
+import entity.Todo;
+import entity.User;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class CreateTeamInteractorTest {
+    CreateTeamInteractor createTeamInteractor;
+
+    @Test
+    public void testExecute() {
+
+        try {
+            // Initialize the interactor with the test cases at the end of the presenter
+            CreateTeamOutputBoundary presenter = new CreateTeamOutputBoundary() {
+                @Override
+                public void prepareSuccessView(CreateTeamOutputData createTeamOutputData) {
+                    assertEquals(createTeamOutputData.getMessage(), "Team Created");
+                    System.out.println("success1");
+                }
+
+                @Override
+                public void prepareFailView(String error) {
+                    assert(Objects.equals(error, "Team Name Already Exists"));
+                }
+            };
+
+            DataAccess dataAccess = new DataAccess();
+            CreateTeamInteractor createTeamInteractor = new CreateTeamInteractor(dataAccess, presenter);
+
+            List<Todo> todoList = new ArrayList<>();
+            List<String> teamList = new ArrayList<>();
+            User testuser = new User("testUser102983748912839", "1234", todoList, teamList);
+            dataAccess.createUser(testuser);
+            EntityMemory.setLoggedInUser(testuser);
+
+            // assert that the interactor is properly initialized
+            assertNotNull(createTeamInteractor);
+
+            // call execute (sleep to avoid errors with DA)
+            Thread.sleep(2000);
+            CreateTeamInputData inputData = new CreateTeamInputData("TestTeam950871023894776");
+            createTeamInteractor.execute(inputData);
+
+            // call again to return an error after waiting a little bit (to avoid error with dataAccess)
+            Thread.sleep(2000);
+            createTeamInteractor.execute(inputData);
+
+            Thread.sleep(2000);
+            dataAccess.deleteTeam("TestTeam950871023894776");
+            Thread.sleep(2000);
+            dataAccess.deleteUser("testUser102983748912839");
+        }
+        catch (InterruptedException ignored) {
+            assert false;
+            System.out.println("Rerun the test");
+        }
+
+
+    }
+
+
+}


### PR DESCRIPTION
CreateTeam had a bug with Data Access; fixed now. (Lists set to null creates an error when calling the iterator in DataAccess, fixed by setting the lists to an empty ArrayList<>(), so the iterator does not return a null reference bug.)

CreateTeam Test created, with 100% coverage except for 2 lines (since they catch ImageKit errors, which I cannot control on my end), that is not related to the actual class's function.